### PR TITLE
Natural earth

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,15 +29,19 @@
         "pk.eyJ1IjoiaWxhYm1lZGlhIiwiYSI6ImNpbHYycXZ2bTAxajZ1c2tzdWU1b3gydnYifQ.AHxl8pPZsjsqoz95-604nw";
 
       const bounds = [
-        [-126.979976, -57.656813], // Southwest coordinates
-        [-17.861337, 22.003946], // Northeast coordinates
+        //  [-114.718862, -58.86926], // Southwest coordinates
+        //  [-18.929193, 24.376253], // Northeast coordinates
       ];
       const map = new mapboxgl.Map({
         container: "map",
-        style: "mapbox://styles/ilabmedia/cl6wg6rdy002715ou4ug6dhrq",
-        center: [-64.395040, -28.864284],
-        zoom:2
-        //maxBounds: bounds
+        style: "mapbox://styles/ilabmedia/cl70m7nqn000m14o1stnelt60",
+        center: [-64.39504, -28.864284],
+        zoom: 3.05,
+        //maxBounds: bounds,
+      });
+
+      map.on("load", function () {
+        map.resize();
       });
 
       map.on("click", (event) => {
@@ -49,13 +53,12 @@
         }
         const feature = features[0];
 
-        console.log(features)
-
         const popup = new mapboxgl.Popup({ offset: [0, -15] })
           .setLngLat(feature.geometry.coordinates)
           .setHTML(
-            `<p><span style="font-weight:bold">${feature.properties.station},</span> ${feature.properties.location}</p><p>${feature.properties.description}</p>`
+            `<p><span style="font-weight:bold">${feature.properties.station}</span><br>${feature.properties.location}</p><p>${feature.properties.description}</p>`
           )
+          .setMaxWidth("250px")
           .addTo(map);
       });
 

--- a/natural-earth/index.html
+++ b/natural-earth/index.html
@@ -29,15 +29,19 @@
         "pk.eyJ1IjoiaWxhYm1lZGlhIiwiYSI6ImNpbHYycXZ2bTAxajZ1c2tzdWU1b3gydnYifQ.AHxl8pPZsjsqoz95-604nw";
 
       const bounds = [
-        [-126.979976, -57.656813], // Southwest coordinates
-        [-17.861337, 22.003946], // Northeast coordinates
+        //  [-114.718862, -58.86926], // Southwest coordinates
+        //  [-18.929193, 24.376253], // Northeast coordinates
       ];
       const map = new mapboxgl.Map({
         container: "map",
-        style: "mapbox://styles/ilabmedia/cl6wg6rdy002715ou4ug6dhrq",
+        style: "mapbox://styles/ilabmedia/cl70m7nqn000m14o1stnelt60",
         center: [-64.39504, -28.864284],
-        zoom: 2,
-        //maxBounds: bounds
+        zoom: 3.05,
+        //maxBounds: bounds,
+      });
+
+      map.on("load", function () {
+        map.resize();
       });
 
       map.on("click", (event) => {
@@ -49,13 +53,12 @@
         }
         const feature = features[0];
 
-        console.log(features);
-
         const popup = new mapboxgl.Popup({ offset: [0, -15] })
           .setLngLat(feature.geometry.coordinates)
           .setHTML(
-            `<p><span style="font-weight:bold">${feature.properties.station},</span> ${feature.properties.location}</p><p>${feature.properties.description}</p>`
+            `<p><span style="font-weight:bold">${feature.properties.station}</span><br>${feature.properties.location}</p><p>${feature.properties.description}</p>`
           )
+          .setMaxWidth("250px")
           .addTo(map);
       });
 


### PR DESCRIPTION
## What
Mapbox requires [a text attribution section](https://docs.mapbox.com/help/getting-started/attribution/#text-attribution) when using any data from OpenStreetMaps. This shows up as an info icon at certain screen sizes and as a string of text at full-width. 

To remove, need a style that doesn't use this data. When required, the text attribution must be present _on_ the map and cannot be moved to another part of the site (like the footer).

The satellite location dataset was created in and is hosted by Mapbox, so the map must have the Mapbox logo in the bottom-left.

## Solution
Build a map-style from scratch using Natural Earth data, [which doesn't require attribution](https://www.naturalearthdata.com/about/terms-of-use/), and update the style colors to match the original.